### PR TITLE
Adding 33 account faucet abuser farm

### DIFF
--- a/20180623.faucetabusers.txt
+++ b/20180623.faucetabusers.txt
@@ -17,6 +17,8 @@ afaytthay
 afoegyi
 afonov4
 afrocandii
+aftarzoli
+aftcpam
 afterback
 agafaabramov
 agatabolsakov
@@ -91,6 +93,7 @@ amelgyi
 amonras
 amurican
 anamko
+anaranal
 anarhiya
 anastasiatalyzin
 anastasiatulepov
@@ -190,6 +193,7 @@ arhipovatamara
 ariellai
 arkasha
 arminiya
+arnabetudail
 arresbirdlou
 arrstria
 arstenes
@@ -480,12 +484,14 @@ bybo
 cacyccuide
 caezar
 caffer
+caloferu
 canadianseh
 cannabutter
 capuratam
 carius
 carloscaetano71
 cartridge
+casimidi
 caslrichrd
 catristy
 cattywampus
@@ -572,6 +578,7 @@ cqt
 cra3yboy
 craigchristt
 cramolg
+crevesalaud
 cribbagewas
 crossplatform
 crucity
@@ -580,7 +587,9 @@ csdn.net
 cudd
 cuddlyyted123
 cudriashove
+cukjoip
 cul68cul
+cultikoplu
 culturne
 cur1os1ty
 cutetle01
@@ -663,6 +672,7 @@ destinysilas
 destribs
 detente
 detnoauki
+devinesseug
 dezlife
 dfktynbyf1208
 dg6ebo
@@ -874,6 +884,7 @@ fightclubalum
 fil44
 filotelist
 findom
+fipofou
 fireeater
 firstone
 fitchpatricfe
@@ -965,6 +976,7 @@ georgioramos
 gerart
 geravelig
 gerhabber
+germanact
 germenu
 gettinmoney
 gezzan
@@ -1107,6 +1119,7 @@ hellotherelol
 helworker
 henry.trevor
 henrybassey
+henryclam
 hensitigang
 heolamok
 hererjack
@@ -1276,6 +1289,7 @@ jattzuk
 jaydenj
 jbow
 jealeon
+jefflangrom
 jefohube
 jen7777
 jennydug
@@ -1303,6 +1317,7 @@ jim77
 jimmymatthews
 joelmacmillan
 johawny
+johnnipatuli
 johnsmithjr
 johnwilliam300
 jointchief
@@ -1421,6 +1436,7 @@ kiborman
 kickstarter.fans
 killok
 kilpan
+kimwilder
 kingedidiong
 kingjinx
 kingleonitas
@@ -1547,6 +1563,7 @@ letsuvekal
 lewispoowas
 lezervil
 libertyytrebil
+lieeil
 liesizigfa
 lifejustatest
 lifeskills
@@ -1576,11 +1593,13 @@ liviya
 lkhant773
 logic9875
 logis7755
+loipar
 lolgets
 lolicomolina
 longpityto
 lorpo
 lottofire
+louisquato
 lovable42
 lovabler
 lovebwk
@@ -1653,6 +1672,7 @@ marinkaf
 maripolskivlados
 markjoseph
 markusman
+marlostive
 marlwin724
 maroni
 marsellos
@@ -1838,6 +1858,7 @@ motmagerbti
 motomiks
 mouriab
 mox1
+mpacaro
 mrbread
 mrcool
 mrgamefun
@@ -1851,6 +1872,7 @@ msbennet
 mtiuli
 mubokox
 mumbomanlv1234
+muownpo
 muricaboy
 muricide
 murmurous87
@@ -1990,6 +2012,7 @@ noneblogger
 norsel
 nosegay
 notarfuncma
+notinthewater
 notube
 novicen
 noy1973
@@ -2110,6 +2133,7 @@ outflow
 outlawedman
 outwain
 ovehter
+overflowideas
 ovthamola
 pacanchik
 pachkasig
@@ -2140,6 +2164,7 @@ paradoksova83
 paragvaec
 parisha
 parlar
+parlogecko
 parusnic
 pasbeltruc
 pasha0331
@@ -2214,11 +2239,13 @@ plohich
 plonkge1234
 ploohish
 plotgapales
+poalphataurus
 poecanfidoor
 poenledger-dex
 poetovagall
 pogonotrophy
 pohland
+poistelez
 pokeremy9887
 pokermenteur
 pol22
@@ -2264,6 +2291,8 @@ postprromoter
 postromoter
 posttpromoter
 postwinmyassag
+pothari
+potiriun
 potpromoter
 potspromoter
 poweratak
@@ -2284,6 +2313,7 @@ prisonrape
 prmobot
 prmoobot
 prodetin
+profabumi
 profectome
 progtinchiapu
 prokar
@@ -2495,6 +2525,7 @@ scorp95
 scorpi
 scottboy
 sebastyan
+secass
 secondchances
 secret12
 secretsauce
@@ -2650,6 +2681,7 @@ sophias
 sor87835
 sorokas
 sortir
+sosaretu
 soulconnector
 speroken
 spicandspan
@@ -2886,6 +2918,7 @@ tonyako
 tonymaf13
 tonymontana666
 toodlesbro
+torananusal
 toriya
 toshca
 totallydude

--- a/full.txt
+++ b/full.txt
@@ -376,6 +376,8 @@ afrocandii
 afsaalar
 afsajir
 aftabkhan123
+aftarzoli
+aftcpam
 afterback
 aftiev
 afwf
@@ -1259,6 +1261,7 @@ anaradwyn
 anarakusdukinos
 anaralako
 anarameena
+anaranal
 anararus
 anarasida
 anarasius
@@ -2082,6 +2085,7 @@ armeno
 armens2012
 armine
 arminiya
+arnabetudail
 arnautochi
 arnetneopran
 arnettelodi
@@ -4418,6 +4422,7 @@ calloyaleighto
 callunabot
 calm3
 calm88
+caloferu
 calransnessmen
 calseco
 calusakutivi
@@ -4533,6 +4538,7 @@ cashbidbot
 cashbot
 casidas
 casido
+casimidi
 casindicho19
 caslrichrd
 casonmesser
@@ -5414,6 +5420,7 @@ cretinustotalus
 crettiburfea
 creukovs
 crevbakotbump
+crevesalaud
 cribbagewas
 crichashi
 cricnews
@@ -5495,11 +5502,13 @@ cudriashove
 cudryawtsewa
 cuelisaro
 cuhoregayaho
+cukjoip
 cul68cul
 culebinoys
 culebra
 culinasalat
 culkovnich
+cultikoplu
 culturne
 culufopepero
 cumamaisstreria
@@ -6341,6 +6350,7 @@ deverteiner
 devexer
 devichevskaya12
 devils666
+devinesseug
 devlikamova1an
 devocekurize
 devolozhan
@@ -8688,6 +8698,7 @@ fiodjevae
 fioniro
 fionmaxi
 fionsamerica
+fipofou
 fipok
 firakhan
 firary
@@ -9640,6 +9651,7 @@ gerinina
 gerivag
 gerlotila
 german356
+germanact
 germankulako
 germenu
 germoin
@@ -10815,6 +10827,7 @@ hennessy82
 henriettesnapp
 henry.trevor
 henrybassey
+henryclam
 hensitigang
 hententnebno
 hentin
@@ -12465,6 +12478,7 @@ jeffersonmcglaug
 jefferyhepner
 jeffger
 jeffiedennison
+jefflangrom
 jeffritt
 jefohube
 jehovahwitness
@@ -12700,6 +12714,7 @@ johnkraven
 johnmelton
 johnnabahena
 johnnahabel
+johnnipatuli
 johnny24234
 johnrevelator
 johnricko
@@ -13813,6 +13828,7 @@ kimieva
 kimmrt
 kimmyle
 kimo
+kimwilder
 kinatan
 kincartkaper
 kindermix
@@ -15711,6 +15727,7 @@ lidsmadyan
 lidstearch
 lidusja8383
 lidyagovor
+lieeil
 liehoecophi
 lienck
 liendombrosky
@@ -16077,6 +16094,7 @@ logunovyka
 loguv
 loidagros
 loijacksubsa
+loipar
 loisematsumura
 loiser
 loiseyoo
@@ -16223,6 +16241,7 @@ lottofire
 lotyb
 louisceasarlab
 louisnoonan
+louisquato
 loulyhe
 loumalee6
 louracallihan
@@ -17163,6 +17182,7 @@ marlenv
 marlenys2323
 marlode
 marlojimenez
+marlostive
 marlow
 marlwin724
 marmalade
@@ -18944,6 +18964,7 @@ moziladorarius
 mozildazar
 mozilla7
 moziusvitaur
+mpacaro
 mparushev
 mpmek
 mponajotova
@@ -19078,6 +19099,7 @@ munkov
 munnana
 munnisingh
 muntyaevv
+muownpo
 mupicehazimi
 murad25
 murad777
@@ -20417,6 +20439,7 @@ notahotdog
 notarfuncma
 notgago
 notic
+notinthewater
 notminewar
 notube
 notut
@@ -21341,6 +21364,7 @@ overatonimifa
 overchuk
 overdan
 overdiana
+overflowideas
 overgrown1987
 overtime82
 ovinmade
@@ -21593,6 +21617,7 @@ parkin
 parko1910
 parksearl
 parlar
+parlogecko
 parnasa
 parninooje
 parno1po
@@ -22291,6 +22316,7 @@ pluno
 plyaskunovakatya
 plyubkin
 pnpit
+poalphataurus
 poarsanna
 pobedas
 pobednov
@@ -22345,6 +22371,7 @@ poinadaw
 poiniconcomp
 pointan
 poiroslehand
+poistelez
 poiun
 poiupoiu
 pojer
@@ -22639,6 +22666,8 @@ potatos
 potaty
 potebenkorasev
 poteriakhin
+pothari
+potiriun
 potlovnik
 potomychto
 potop
@@ -22827,6 +22856,7 @@ prodhardpractia
 prodip012
 prodip0123
 proesnov
+profabumi
 profberselfluc
 profectome
 profess
@@ -25290,6 +25320,7 @@ sebjohn
 sebryack
 sebuviry
 secaonsdar
+secass
 seccermmio
 sechka
 secionerlur
@@ -26765,6 +26796,7 @@ sortanov
 sortir
 sorvenko
 sosadamyan
+sosaretu
 soshchofev
 sosip
 sosisa
@@ -28748,6 +28780,7 @@ topshercfecrea
 topsopfew
 toptema
 topzehn
+torananusal
 torapyrva
 torchok
 torfian


### PR DESCRIPTION
This adds another small faucet abuse farm using 33 accounts with steem delegations. 
Their voting patterns are very obvious:

![vote_data](https://user-images.githubusercontent.com/27223336/50717284-82f0ec00-1086-11e9-8aea-196609ec8382.png)
